### PR TITLE
Added `postinstall` script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "A full-featured Webpack setup with hot-reload, lint-on-save, unit testing & css extraction.",
   "scripts": {
     "docs": "cd docs && gitbook serve",
-    "docs:deploy": "bash ./deploy-docs.sh"
+    "docs:deploy": "bash ./deploy-docs.sh",
+    "postinstall": "node ./postinstall.js"
   },
   "devDependencies": {
     "vue-cli": "^2.8.1"

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,6 @@
+(function() {
+  console.log('This template can be quickly deployed as a Cordova App.\n' +
+    'By using Monaca CLI you can easily Preview, Debug, Build\n' +
+    'and Publish your App in no time. To get started, check:\n\n' +
+    'https://docs.monaca.io/en/monaca_cli/samples/vue_onsen/\n');
+})();


### PR DESCRIPTION
@frandiox @masahirotanaka 

This simple change is needed to give Vue users some more information about the possible integration of this template and Monaca CLI. Feel free to change the content if the message if you can think about something more appropriate.
I didn't style the message as the messages displayed by Vue CLI are not styled as well.

To get a preview of the message, just execute `npm run postinstall `