### PR TITLE
Add cordova.js to index.html

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy" content="default-src * data: gap: https://ssl.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'">
     <title>{{ name }}</title>
+    <script src="cordova.js"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
Maybe I'm wrong, but isn't ```cordova.js``` lacking here?
In my case, when I do ```cordova run android```, ```window.cordova``` is undefined. Everything related to cordova is not working (including the press physical back button to pop page feature on Android).
After adding this line to ```index.html```, the problems are solved.